### PR TITLE
ci: extract linting to a parallel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,16 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci --omit=dev
       - run: npm ci
-      - run: npm run test:types
-      - run: npm run test:lint
-        if: matrix.os != 'windows-latest'
       - run: npm run test:unit
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm ci
+      - run: npm run test:types
+      - run: npm run lint
 
   test-locales:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Stop running linters for every Node.js version we support. It's enough to run linters on a single Node.js version.

This should fix the CI failure in #710 caused by a linter crash on Node.js v18.
