### PR TITLE
Allow comma separated SUBNET_FILTER values

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -85,7 +85,7 @@ const maybeReportErrorToSentry = (/** @type {unknown} */ err) => {
 }
 
 const matchesSubnetFilter = (subnet) =>
-  SUBNET_FILTER === '' || subnet === SUBNET_FILTER
+  SUBNET_FILTER === '' || SUBNET_FILTER.split(',').includes(subnet);
 
 const capitalize = (str) => `${str.charAt(0).toUpperCase()}${str.slice(1)}`
 


### PR DESCRIPTION
Allow to specify multiple allowed subnets in SUBNET_FILTER by separating them with comma. This will accept single subnet, such as SUBNET_FILTER=spark but also multiple subnets, such as SUBNET_FILTER=spark,arweave,walrus.