### PR TITLE
ci: auto-approve neostandard updates

### DIFF
--- a/.github/workflows/dependabot-auto-approve-minor.yml
+++ b/.github/workflows/dependabot-auto-approve-minor.yml
@@ -24,7 +24,7 @@ jobs:
           - execa
           - '@ipld/car'
           - '@filecoin-station/spark-impact-evaluator'
-          - standard
+          - neostandard
           - p-retry
           - cross-spawn
           - nanoid


### PR DESCRIPTION
This is a follow-up for #710 where we switched from standard to neostandard.
