### PR TITLE
deps: upgrade Zinnia to v0.22.1

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -7,7 +7,7 @@ import pRetry from 'p-retry'
 import timers from 'node:timers/promises'
 import { join } from 'node:path'
 
-const ZINNIA_DIST_TAG = 'v0.20.3'
+const ZINNIA_DIST_TAG = 'v0.22.1'
 const SUBNETS = [
   {
     subnet: 'spark',


### PR DESCRIPTION
Release notes:
https://github.com/CheckerNetwork/zinnia/releases/tag/v0.22.1
