### PR TITLE
chore: Remove arweave and walrus checker modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,6 @@ For the JSON output, the following event types exist:
 Set the flag `--experimental` to run subnets not yet considered safe for
 production use. _Run this at your own risk!_
 
-Checker Modules currently in experimental mode:
-
-- [Arweave](https://github.com/CheckerNetwork/arweave-checker/)
-- [Walrus](https://github.com/CheckerNetwork/walrus-checker/)
-
 ### `$ checker --help`
 
 Show help.

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -13,16 +13,6 @@ const SUBNETS = [
     ipnsKey: 'k51qzi5uqu5dlej5gtgal40sjbowuau5itwkr6mgyuxdsuhagjxtsfqjd6ym3g',
     experimental: false,
   },
-  {
-    subnet: 'arweave',
-    ipnsKey: 'k51qzi5uqu5dgwm6tk4gibgfqbqjopwdtlphvyczrixay6oesadjdxt1eorimg',
-    experimental: true,
-  },
-  {
-    subnet: 'walrus',
-    ipnsKey: 'k51qzi5uqu5dghv7chp14rx3w89xwbbi2pwzpz1xt02ddpcev6j7guyg60yi4m',
-    experimental: true,
-  },
 ]
 const {
   TARGET_ARCH = os.arch(),

--- a/test/checker.js
+++ b/test/checker.js
@@ -34,14 +34,6 @@ describe('Checker', () => {
     assert.strictEqual(ps.exitCode, null)
     stopChecker()
   })
-  it('runs experimental subnets', () => {
-    it('runs Arweave & Walrus', async () => {
-      const ps = startChecker(['--experimental'])
-      await streamMatch(ps.stdout, 'Arweave subnet started.')
-      await streamMatch(ps.stdout, 'Walrus subnet started.')
-      stopChecker()
-    })
-  })
   it('outputs events', async () => {
     const ps = startChecker()
     await Promise.all([


### PR DESCRIPTION
Removes arweave and walrus checkers and all related code and docs.